### PR TITLE
Touch ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ hush {
 
 ### Manually Running Sub-Tasks
 
-Subtasks are given a unique name to prevent name collision. You may run them by prepending `hush`. For example:
+Subtasks use their original names. You may run them per usual. For example:
 
-   - `./gradlew hushDependencyCheck`
-   - `./gradlew hushDependencyCheckAnalyze`
+   - `./gradlew dependencyCheck`
+   - `./gradlew dependencyCheckAnalyze`

--- a/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
@@ -77,12 +77,22 @@ class HushDeltaAnalyzer(private val vulnerabilities: HashMap<String, HushVulnera
         }
 
         if (unneededSuppressions.isNotEmpty() && outputUnneeded) {
+            val multiWhitespace = Regex("\\s{2,}")
             val supVerbiage = if (unneededSuppressions.size > 1) "suppressions" else "suppression"
 
             println("${yellow(unneededSuppressions.size.toString())} ${red("unnecessary $supVerbiage found!")}")
 
             for (suppression in unneededSuppressions) {
-                println("   - ${suppression.cve}")
+                val notes = suppression.notes
+                    ?.replace("\n", "")
+                    ?.replace(multiWhitespace, " ")
+                    ?.trim()
+
+                if (notes != null) {
+                    println("   - ${suppression.cve} ($notes)")
+                } else {
+                    println("   - ${suppression.cve}")
+                }
             }
 
             println("\n")

--- a/src/main/kotlin/com/mx/hush/core/HushEngine.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushEngine.kt
@@ -46,7 +46,6 @@ class HushEngine(private val project: Project, private val driver: HushDriver) {
 
     fun analyze() {
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), driver)
-        analyzer.printReport(getConfigParameter("outputUnneeded"), getConfigParameter("outputSuggested"))
 
         if (getConfigParameter("writeSuggested")) {
             analyzer.writeSuggestedSuppressions()
@@ -55,6 +54,7 @@ class HushEngine(private val project: Project, private val driver: HushDriver) {
             println(green("Suppression file written."))
         }
 
+        analyzer.printReport(getConfigParameter("outputUnneeded"), getConfigParameter("outputSuggested"))
         analyzer.passOrFail(getConfigParameter("failOnUnneeded"))
     }
 

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckDriver.kt
@@ -23,6 +23,7 @@ import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
 import org.owasp.dependencycheck.gradle.tasks.Analyze
 import org.owasp.dependencycheck.reporting.ReportGenerator
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.StringWriter
 import java.util.*
 import javax.xml.bind.JAXBContext
@@ -38,34 +39,56 @@ class DependencyCheckDriver(private val project: Project) : HushDriver(project) 
      * and suppressions.
      */
     override fun setupProject() {
-        var dependencyCheckExtension = project.extensions.create("hushDependencyCheck", DependencyCheckExtension::class.java)
-        project.tasks.register("hushDependencyCheckAnalyze", Analyze::class.java)
-
-        dependencyCheckExtension.data.directory = "${project.projectDir}/.dependency-check-data"
-        dependencyCheckExtension.cveValidForHours = 24
-        dependencyCheckExtension.failBuildOnCVSS = 11F
-        dependencyCheckExtension.format = ReportGenerator.Format.JSON
-        dependencyCheckExtension.skipConfigurations.clear()
-        dependencyCheckExtension.skipConfigurations.addAll(
-            Arrays.asList("checkstyle", "detekt", "detektPlugins",
-            "pmd", "spotbugs", "spotbugsPlugins", "spotbugsSlf4j"))
-        dependencyCheckExtension.suppressionFile = null
-        dependencyCheckExtension.outputDirectory = "${project.buildDir}/reports/hush/report.json"
-        dependencyCheckExtension.showSummary = false
-
         project.afterEvaluate {
+            // Create new dependencyCheck extension, ignoring errors from the extension already existing
+            try {
+                project.extensions.create("dependencyCheck", DependencyCheckExtension::class.java)
+            } catch (ignored: Exception) {
+
+            }
+
+            // Register the task, ignoring errors from the task already being registered
+            try {
+                project.tasks.register("dependencyCheckAnalyze", Analyze::class.java)
+            } catch (ignored: Exception) {
+
+            }
+
+            // Make sure the extension gets configured just before the dependencyCheckAnalyze task runs
+            project.tasks.named("dependencyCheckAnalyze")
+                .get()
+                .doFirst {
+                    val dependencyCheckExtension = project.extensions.getByName("dependencyCheck") as DependencyCheckExtension
+
+                    dependencyCheckExtension.data.directory = "${project.projectDir}/.dependency-check-data"
+                    dependencyCheckExtension.cveValidForHours = 24
+                    dependencyCheckExtension.failBuildOnCVSS = 11F
+                    dependencyCheckExtension.format = ReportGenerator.Format.JSON
+                    dependencyCheckExtension.skipConfigurations.clear()
+                    dependencyCheckExtension.skipConfigurations.addAll(
+                        Arrays.asList("checkstyle", "detekt", "detektPlugins",
+                            "pmd", "spotbugs", "spotbugsPlugins", "spotbugsSlf4j"))
+                    dependencyCheckExtension.suppressionFile = null
+                    dependencyCheckExtension.outputDirectory = "${project.buildDir}/reports/hush/report.json"
+                    dependencyCheckExtension.showSummary = false
+                }
+
             project.tasks.named("hushReport")
                 .get()
-                .dependsOn(project.tasks.named("hushDependencyCheckAnalyze"))
+                .dependsOn(project.tasks.named("dependencyCheckAnalyze"))
         }
     }
 
     /**
-     * Get vulnerabilities from the dependencyCheckAnalyze tasks's output file and map to HushVaulnerability
+     * Get vulnerabilities from the dependencyCheckAnalyze task's output file and map to HushVulnerability
      */
     override fun getVulnerabilities(): HashMap<String, HushVulnerability> {
         val scanReport = getReport()
         val vulnerabilities = HashMap<String, HushVulnerability>()
+
+        if (scanReport == null) {
+            return vulnerabilities
+        }
 
         for (vulnerability in scanReport.getVulnerabilities()) {
             val mappedVulnerability = HushVulnerability(vulnerability.key, vulnerability.value.description, vulnerability.value.references[0].url)
@@ -134,8 +157,12 @@ class DependencyCheckDriver(private val project: Project) : HushDriver(project) 
         File("./dependency_suppression.xml").writeText(suppressions)
     }
 
-    private fun getReport(): DependencyCheckScanReport {
-        return Gson().fromJson(readFileDirectlyAsText("${project.buildDir}/reports/hush/report.json"), DependencyCheckScanReport::class.java)
+    private fun getReport(): DependencyCheckScanReport? {
+        return try {
+            Gson().fromJson(readFileDirectlyAsText("${project.buildDir}/reports/hush/report.json"), DependencyCheckScanReport::class.java)
+        } catch (ignored: FileNotFoundException) {
+            null
+        }
     }
 
     private fun readFileDirectlyAsText(fileName: String): String

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckDriver.kt
@@ -25,7 +25,8 @@ import org.owasp.dependencycheck.reporting.ReportGenerator
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.StringWriter
-import java.util.*
+import java.util.Arrays
+import java.util.Collections
 import javax.xml.bind.JAXBContext
 import kotlin.collections.HashMap
 


### PR DESCRIPTION
Three noteworthy changes:

- Rename all tasks / extensions back to original names.
- Try/catch blocks in case something else loads in extensions or registers tasks first.
- Hook into the analyzer task, and configure in a `doFirst` to ensure it always has the proper configuration.

On the more minor side, re-ordered output to show the report _after_ generating a new file, which should show proper output. Also added notes to the unneeded suppression output for easier closing of tickets (if a ticket is linked in a note).