### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,15 @@ Subtasks use their original names. You may run them per usual. For example:
 
    - `./gradlew dependencyCheck`
    - `./gradlew dependencyCheckAnalyze`
+
+### Local development workflow with Gitlab tokens
+
+`./gradlew hushGitlabToken` will enable you to store a token locally, so you do not need to add a token to your `build.gradle`.
+
+First, configure your Gitlab URL. Then, run the task (`./gradlew hushGitlabToken`). You will be given a URL to go to (but you can always just navigate to your profile in Gitlab) and generate a token. It is highly recommended that the token you generate has **read-only access**, for security purposes. Hush does not currently have any need for write permissions at all.
+
+When you run this task and input your token, a file will be created in `<user home>/hush` called `.gitlab-token`. This file will act as a fallback for scenarios that the token is not available via configuration or parameters. This allows an organization to avoid committing tokens to source control.
+
+#### Notes regarding overrides
+
+If you use the local development token strategy, and later configure a token (use supply a token via command line), it will be overridden. The token file is a fallback which is only used if a token is not configured. Please keep this in mind.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Report.
    - `failOnUnneeded` (**enabled** by default): Throw if there are unnecessary suppressions in the suppression file.
    - `outputSuggested` (**enabled** by default): Output the suggested suppression file contents.
    - `writeSuggested` (**disabled** by default): Write the suggested suppressions directly to the suppression file.
+   - `gitlab` (**disabled** by default -- parameter only): Enable the Gitlab issue searching feature.
+   - `gitlabConfiguration`:
+     - `enabled`: Whether the Gitlab configuration is enabled.
+     - `url`: The base URL of your Gitlab instance.
+     - `token`: A valid token for interacting with your Gitlab API.
+     - `populateNotesOnMatch`: Add a matching Gitlab issue URL to the notes of suppressions.
+     - `duplicateStrategy`: Either `oldest` or `newest`. If more than one issue is found matching a CVE, which one to use.
 
 You may prepend `no` to any of the above flags, and the feature will be disabled (such as `noOutputUnneeded`).
 
@@ -54,6 +61,13 @@ hush {
    failOnUnneeded = true
    outputSuggested = true
    writeSuggested = false
+   gitlabConfiguration {
+    enabled = false
+    url = ""
+    token = ""
+    populateNotesOnMatch = true
+    duplicateStrategy = "oldest"
+  }
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.6.10"
+    id "org.jetbrains.kotlin.plugin.serialization" version "1.6.10"
     id "groovy"
     id "java"
     id "maven-publish"
@@ -7,7 +8,7 @@ plugins {
 }
 
 group "com.mx.hush"
-version "1.0.6"
+version "1.1.0"
 sourceCompatibility = 1.8
 
 repositories {
@@ -21,6 +22,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     implementation "com.google.code.gson:gson:2.+"
     implementation "org.owasp:dependency-check-gradle:7.1.+"
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
+    implementation("com.github.kittinunf.fuel:fuel:2.3.1")
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.+'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.+'

--- a/src/main/kotlin/com/mx/hush/HushExtension.kt
+++ b/src/main/kotlin/com/mx/hush/HushExtension.kt
@@ -47,6 +47,7 @@ open class GitlabConfiguration {
     var url: String = ""
     var token: String = ""
     var populateNotesOnMatch: Boolean = true
+    var duplicateStrategy: String = "oldest"
 
     fun validateConfiguration() {
         if (!enabled) {

--- a/src/main/kotlin/com/mx/hush/HushExtension.kt
+++ b/src/main/kotlin/com/mx/hush/HushExtension.kt
@@ -15,9 +15,58 @@
  */
 package com.mx.hush
 
-open class HushExtension (
-    var outputUnneeded: Boolean = true,
-    var failOnUnneeded: Boolean = true,
-    var outputSuggested: Boolean = true,
-    var writeSuggested: Boolean = false,
-)
+import com.mx.hush.core.exceptions.GitlabConfigurationViolation
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import java.io.File
+import javax.inject.Inject
+
+open class HushExtension @Inject constructor(
+    objects: ObjectFactory,
+) {
+    var outputUnneeded: Boolean = true
+    var failOnUnneeded: Boolean = true
+    var outputSuggested: Boolean = true
+    var writeSuggested: Boolean = false
+    val gitlabConfiguration: GitlabConfiguration = objects.newInstance(GitlabConfiguration::class.java)
+
+    fun gitlabConfiguration(action: Action<GitlabConfiguration>) {
+        action.execute(gitlabConfiguration)
+    }
+
+    companion object {
+        fun Project.hush(): HushExtension {
+            return extensions.create("hush", HushExtension::class.java)
+        }
+    }
+}
+
+open class GitlabConfiguration {
+    var enabled: Boolean = false
+    var url: String = ""
+    var token: String = ""
+    var populateNotesOnMatch: Boolean = true
+
+    fun validateConfiguration() {
+        if (!enabled) {
+            return
+        }
+
+        if (url.isEmpty()) {
+            throw GitlabConfigurationViolation("No Gitlab URL defined.")
+        }
+
+        if (token.isEmpty()) {
+            if (!localTokenExists()) {
+                throw GitlabConfigurationViolation("No Gitlab token defined. Please add a token to your configuration, run the task with the gitlabConfiguration.token parameter, or run ./gradlew hushGitlabToken to set your token.")
+            }
+
+            token = File("${System.getProperty("user.home")}/hush/.gitlab-token").readText()
+        }
+    }
+
+    private fun localTokenExists(): Boolean {
+        return File("${System.getProperty("user.home")}/hush/.gitlab-token").exists()
+    }
+}

--- a/src/main/kotlin/com/mx/hush/HushPlugin.kt
+++ b/src/main/kotlin/com/mx/hush/HushPlugin.kt
@@ -17,7 +17,9 @@ package com.mx.hush
 
 import com.mx.hush.core.HushEngine
 import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
+import com.mx.hush.core.exceptions.GitlabConfigurationViolation
 import com.mx.hush.core.exceptions.HushValidationViolation
+import com.mx.hush.core.models.red
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import java.io.File
@@ -46,6 +48,11 @@ class HushPlugin() : Plugin<Project> {
             }
 
             task.doLast {
+                if (hushEngine.getGitlabUrl().isBlank()) {
+                    println(red("Please configure a Gitlab URL."))
+                    throw GitlabConfigurationViolation("No Gitlab URL configured.")
+                }
+
                 println("Please visit ${hushEngine.getGitlabTokenUrl()}, add a token, and paste it below:")
                 val token = readLine()
 

--- a/src/main/kotlin/com/mx/hush/HushPlugin.kt
+++ b/src/main/kotlin/com/mx/hush/HushPlugin.kt
@@ -16,21 +16,47 @@
 package com.mx.hush
 
 import com.mx.hush.core.HushEngine
-import com.mx.hush.core.drivers.DependencyCheckDriver
+import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
 import com.mx.hush.core.exceptions.HushValidationViolation
-import com.mx.hush.core.models.red
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import java.io.File
 
-class HushPlugin : Plugin<Project> {
+
+class HushPlugin() : Plugin<Project> {
     override fun apply(project: Project) {
-        val dependencyCheckDriver = DependencyCheckDriver(project)
+        val dependencyCheckDriver = DependencyCheckVulnerabilityScanDriver(project)
         val hushEngine = HushEngine(project, dependencyCheckDriver)
 
         project.tasks.register("hushReport") { task ->
+            task.description = "Check dependencies and output a report."
             task.doLast {
                 hushEngine.analyze()
             }
         }
+
+        project.tasks.register("hushGitlabToken") { task ->
+            task.description = "Set a local Gitlab token, for use in Hush, to avoid storing in a Git repository."
+
+            val tokenFile = File("${System.getProperty("user.home")}/hush/.gitlab-token")
+
+            task.doFirst {
+                File("${System.getProperty("user.home")}/hush").mkdirs()
+                tokenFile.createNewFile()
+            }
+
+            task.doLast {
+                println("Please visit ${hushEngine.getGitlabTokenUrl()}, add a token, and paste it below:")
+                val token = readLine()
+
+                if (token.isNullOrBlank()) {
+                    throw HushValidationViolation("Invalid token entered. Exiting.")
+                }
+
+                tokenFile.writeText(token)
+            }
+        }
+
+
     }
 }

--- a/src/main/kotlin/com/mx/hush/core/HushEngine.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushEngine.kt
@@ -140,6 +140,12 @@ class HushEngine(private val project: Project, private val scanDriver: HushVulne
                             println("Gitlab populateNotesOnMatch set to ${parameter.value.toString().toBoolean()} via parameter")
                         }
 
+                        "duplicatestrategy" -> {
+                            val strategy = if (parameter.value.toString() == "oldest") "oldest" else "newest"
+                            extension.gitlabConfiguration.duplicateStrategy = strategy
+                            println("Gitlab duplicateStrategy set to $strategy via parameter")
+                        }
+
                         else -> {
                             println(red("Unknown Gitlab configuration property '${keys[1]}'"))
                         }

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
@@ -33,7 +33,7 @@ import kotlin.collections.HashMap
 /**
  * Driver for leveraging the dependencyCheckAnalyze plugin
  */
-class DependencyCheckDriver(private val project: Project) : HushDriver(project) {
+class DependencyCheckVulnerabilityScanDriver(private val project: Project) : HushVulnerabilityScanDriver(project) {
 
     /**
      * Resource directory paths used for dependency analysis. Create, Read, Write.

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -21,7 +21,7 @@ import com.mx.hush.GitlabConfiguration
 import com.mx.hush.core.models.gitlab.GitlabIssue
 
 class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfiguration) : HushIssueSearchDriver() {
-    private var urlFallbackMessage: String = "No Gitlab issue found. Please create and issue and update this note."
+    private var urlFallbackMessage: String = "No Gitlab issue found. Please create an issue and update this note."
 
     override fun findIssueUrl(cve: String): String {
         val (_, _, result) = "${gitlabConfiguration.url}/api/v4/issues"

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -33,6 +33,10 @@ class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfigurati
 
         val issues = result.component1() ?: return urlFallbackMessage
 
+        if (gitlabConfiguration.duplicateStrategy != "oldest") {
+            return issues.first().webUrl
+        }
+
         return issues.last().webUrl
     }
 

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.drivers
+
+import com.github.kittinunf.fuel.core.extensions.authentication
+import com.github.kittinunf.fuel.httpGet
+import com.mx.hush.GitlabConfiguration
+import com.mx.hush.core.models.gitlab.GitlabIssue
+
+class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfiguration) : HushIssueSearchDriver() {
+    private var urlFallbackMessage: String = "No Gitlab issue found. Please create and issue and update this note."
+
+    override fun findIssueUrl(cve: String): String {
+        val (_, _, result) = "${gitlabConfiguration.url}/api/v4/issues"
+            .httpGet(listOf("search" to cve, "scope" to "all"))
+            .authentication()
+            .bearer(gitlabConfiguration.token)
+            .responseObject(GitlabIssue.Deserializer())
+
+        val issues = result.component1() ?: return urlFallbackMessage
+
+        return issues.last().webUrl
+    }
+
+    override fun isValidNote(note: String): Boolean {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -18,6 +18,7 @@ package com.mx.hush.core.drivers
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.httpGet
 import com.mx.hush.GitlabConfiguration
+import com.mx.hush.core.models.HushSuppression
 import com.mx.hush.core.models.gitlab.GitlabIssue
 
 class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfiguration) : HushIssueSearchDriver() {
@@ -36,6 +37,10 @@ class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfigurati
     }
 
     override fun isValidNote(note: String): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun validateNotes(suppressions: List<HushSuppression>) {
         TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.drivers
+
+import org.gradle.api.Project
+
+abstract class HushIssueSearchDriver() {
+    abstract fun findIssueUrl(cve: String): String
+    abstract fun isValidNote(note: String): Boolean
+}

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
@@ -15,9 +15,10 @@
  */
 package com.mx.hush.core.drivers
 
-import org.gradle.api.Project
+import com.mx.hush.core.models.HushSuppression
 
 abstract class HushIssueSearchDriver() {
     abstract fun findIssueUrl(cve: String): String
     abstract fun isValidNote(note: String): Boolean
+    abstract fun validateNotes(suppressions: List<HushSuppression>)
 }

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
@@ -22,7 +22,7 @@ import org.gradle.api.Project
 /**
  * Driver class for creating implementations with plugins
  */
-abstract class HushDriver(private val project: Project) {
+abstract class HushVulnerabilityScanDriver(private val project: Project) {
     /**
      * All logic which should run within Hush's apply() method
      */

--- a/src/main/kotlin/com/mx/hush/core/exceptions/GitlabConfigurationViolation.kt
+++ b/src/main/kotlin/com/mx/hush/core/exceptions/GitlabConfigurationViolation.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.exceptions
+
+class GitlabConfigurationViolation(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/Assignee.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/Assignee.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Assignee(
+    val state: String,
+    val id: Int,
+    val name: String,
+    @SerialName("web_url")
+    @SerializedName("web_url")
+    val webUrl: String,
+    @SerialName("avatar_url")
+    @SerializedName("avatar_url")
+    val avatarUrl: String?,
+    val username: String,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/Author.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/Author.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Author(
+    val state: String,
+    val id: Int,
+    @SerialName("web_url")
+    @SerializedName("web_url")
+    val webUrl: String,
+    val name: String,
+    @SerialName("avatar_url")
+    @SerializedName("avatar_url")
+    val avatarUrl: String?,
+    val username: String,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/GitlabIssue.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/GitlabIssue.kt
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.github.kittinunf.fuel.core.ResponseDeserializable
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GitlabIssue(
+    val state: String,
+    val description: String,
+    val Author: Author,
+    val milestone: Milestone?,
+    @SerialName("project_id")
+    @SerializedName("project_id")
+    val projectId: Int,
+    val assignees: List<Assignee>?,
+    val assignee: Assignee?,
+    val type: String,
+    @SerialName("updated_at")
+    @SerializedName("updated_at")
+    val updatedAt: String?,
+    @SerialName("closed_at")
+    @SerializedName("closed_at")
+    val closedAt: String?,
+    @SerialName("closed_by")
+    @SerializedName("closed_by")
+    val closedBy: String?,
+    val id: Int,
+    val title: String,
+    @SerialName("created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+    @SerialName("moved_to_id")
+    @SerializedName("moved_to_id")
+    val movedToId: Int?,
+    val iid: Int,
+    val labels: List<String>?,
+    val upvotes: Int,
+    val downvotes: Int,
+    @SerialName("merge_requests_count")
+    @SerializedName("merge_requests_count")
+    val mergeRequestsCount: Int,
+    @SerialName("user_notes_count")
+    @SerializedName("user_notes_count")
+    val userNotesCount: Int,
+    @SerialName("due_date")
+    @SerializedName("due_date")
+    val dueDate: String?,
+    @SerialName("web_url")
+    @SerializedName("web_url")
+    val webUrl: String,
+    val references: References,
+    @SerialName("time_stats")
+    @SerializedName("time_stats")
+    val timeStats: TimeStats,
+    @SerialName("has_tasks")
+    @SerializedName("has_tasks")
+    val hasTasks: Boolean,
+    @SerialName("task_status")
+    @SerializedName("task_status")
+    val taskStatus: String?,
+    val confidential: Boolean,
+    @SerialName("discussion_locked")
+    @SerializedName("discussion_locked")
+    val discussionLocked: String?,
+    @SerialName("issue_type")
+    @SerializedName("issue_type")
+    val issueType: String,
+    val severity: String,
+    @SerialName("_links")
+    @SerializedName("_links")
+    val links: Links,
+    @SerialName("task_completion_status")
+    @SerializedName("task_completion_status")
+    val taskCompletionStatus: TaskCompletionStatus,
+    val weight: Int?,
+    @SerialName("service_desk_reply_to")
+    @SerializedName("service_desk_reply_to")
+    val serviceDeskReplyTo: String?,
+    @SerialName("epic_iid")
+    @SerializedName("epic_iid")
+    val epicIid: Int?,
+    val epic: String?,
+    val iteration: Iteration?,
+) {
+    class Deserializer : ResponseDeserializable<Array<GitlabIssue>> {
+        override fun deserialize(content: String): Array<GitlabIssue>
+                = Gson().fromJson(content, Array<GitlabIssue>::class.java)
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/GitlabIssueResponse.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/GitlabIssueResponse.kt
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.github.kittinunf.fuel.core.ResponseDeserializable
+import com.google.gson.Gson
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GitlabIssueResponse(
+    val issues: List<GitlabIssue>,
+) {
+    class Deserializer : ResponseDeserializable<GitlabIssueResponse> {
+        override fun deserialize(content: String) = Gson().fromJson(content, GitlabIssueResponse::class.java)
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/Iteration.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/Iteration.kt
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Iteration(
+    val id: Int,
+    val iid: Int,
+    val sequence: Int,
+    @SerialName("group_id")
+    @SerializedName("group_id")
+    val groupId: Int,
+    val state: Int,
+    @SerialName("created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+    @SerialName("updated_at")
+    @SerializedName("updated_at")
+    val updatedAt: String?,
+    @SerialName("start_date")
+    @SerializedName("start_date")
+    val startDate: String?,
+    @SerialName("due_date")
+    @SerializedName("due_date")
+    val dueDate: String?,
+    @SerialName("web_url")
+    @SerializedName("web_url")
+    val webUrl: String,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/Links.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/Links.kt
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Links(
+    val self: String,
+    val notes: String?,
+    @SerialName("award_emoji")
+    @SerializedName("award_emoji")
+    val awardEmoji: String?,
+    val project: String?,
+    @SerialName("closed_as_duplicate_of")
+    @SerializedName("closed_as_duplicate_of")
+    val closedAsDuplicateOf: String?,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/Milestone.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/Milestone.kt
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Milestone(
+    @SerialName("project_id")
+    @SerializedName("project_id")
+    val projectId: Int,
+    val description: String,
+    val state: String,
+    @SerialName("due_date")
+    @SerializedName("due_date")
+    val dueDate: String?,
+    val iid: Int,
+    @SerialName("created_at")
+    @SerializedName("created_at")
+    val createdAt: String,
+    val title: String,
+    val id: Int,
+    @SerialName("updated_at")
+    @SerializedName("updated_at")
+    val updatedAt: String?,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/References.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/References.kt
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class References(
+    val short: String,
+    val relative: String,
+    val full: String,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/TaskCompletionStatus.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/TaskCompletionStatus.kt
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TaskCompletionStatus(
+    val count: Int,
+    @SerialName("completed_count")
+    @SerializedName("completed_count")
+    val completedCount: Int,
+)

--- a/src/main/kotlin/com/mx/hush/core/models/gitlab/TimeStats.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/gitlab/TimeStats.kt
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.models.gitlab
+
+import com.google.gson.annotations.SerializedName
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TimeStats(
+    @SerialName("time_estimate")
+    @SerializedName("time_estimate")
+    val timeEstimate: Int?,
+    @SerialName("total_time_spent")
+    @SerializedName("total_time_spent")
+    val totalTimeSpent: Int?,
+    @SerialName("human_time_estimate")
+    @SerializedName("human_time_estimate")
+    val humanTimeEstimate: String?,
+    @SerialName("human_total_time_spent")
+    @SerializedName("human_total_time_spent")
+    val humanTotalTimeSpent: String?,
+)


### PR DESCRIPTION
# What's new

## Overview

Upon finding vulnerabilities, Hush can now search Gitlab for an issue related to the suppression and automatically add it as a note. With this new feature, comes a new set of configuration properties:

- gitlabConfiguration.enabled (defaults to false)
   - Enables or disables Gitlab issue searching.
- gitlabConfiguration.url (defaults to empty string)
   - The _base_ URL of your Gitlab instance.
- gitlabConfiguration.token (defaults to empty string)
   - The access token for making API requests to your Gitlab instance.
- gitlabConfiguration.populateNotesOnMatch (defaults to true)
   - Automatically put the URL of a matched ticket into the suppression when suggesting suppressions.
- gitlabConfiguration.duplicateStrategy (defaults to "oldest")
   - "oldest": Use the oldest matched ticket if there are duplicates
   - "newest": Use the newest matched ticket if there are duplicates

(build.gradle)
```
hush {
  gitlabConfiguration {
    enabled = false
    url = ""
    token = ""
    populateNotesOnMatch = true
    duplicateStrategy = "oldest"
  }
}
```

(terminal)
```
./gradlew hushReport -PnoGitlab
```
_Disables the Gitlab search feature._

```
./gradlew hushReport -PgitlabConfiguration.enabled=true -PgitlabConfiguration.url="myGitlab.myCompany.com" -PgitlabConfiguration.token="myGitlabToken"
```
_Enable via command line, and set the URL + Token._

## New task

With the new feature, there is a new task that can be ran as a matter of convenience for local development. Since it is not advisable to publish a token to version control, a secondary option is available: `./gradlew hushGitlabToken`

### Working with `hushGitlabToken`

First, configure your Gitlab URL. Then, run the task (`./gradlew hushGitlabToken`). You will be given a URL to go to (but you can always just navigate to your profile in Gitlab) and generate a token. It is highly recommended that the token you generate has **read-only access**, for security purposes. Hush does not currently have any need for write permissions at all.

When you run this task and input your token, a file will be created in `<user home>/hush` called `.gitlab-token`. This file will act as a fallback for scenarios that the token is not available via configuration or parameters. This allows an organization to avoid committing tokens to source control.

#### Notes regarding overrides

If you use the local development token strategy, and later configure a token (use supply a token via command line), it will be overridden. The token file is a fallback which is only used if a token is not configured. Please keep this in mind.