### PR TITLE
1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,56 +4,54 @@ A wrapper for dependency vulnerability plugins which makes it easier to manage s
 
 Jitpack: https://jitpack.io/p/mxenabled/hush
 
-## Use
+## Commands
+The following commands are available:
 
-### Basic Usage
+- `./gradlew hushReport`: Scan for vulnerabilities in dependencies, unneeded suppressions in the suppression file, and 
+output a report.
+- `./gradlew hushWriteSuppressions`: Write the suggested suppressions to the suppression file. Requires having 
+previously ran `hushReport`.
+- `./gradlew hushConfigureGitlab`: Step-by-step configuration of Gitlab, which will be stored in
+  `<user home>/.config/hush/hush-config.json` to prevent committing tokens to source control. Alternatively, this file can be 
+manually created / edited with these properties: `enabled`, `url`, `token`, `populateNotesOnMatch`, and 
+`duplicateStrategy`.
 
-In a terminal, simply run `./gradlew hushReport` to get a report of new vulnerabilities, unnecessary suppressions, and 
-suggested suppression file contents.
+## Arguments / Config
 
-### Arguments / Config
+### Command Line Arguments
 
-The following flags can be leveraged to alter behavior:
+#### hushReport
 
-   - `outputUnneeded` (**enabled** by default): Output the list of suppressions which are not necessary, in the Hush 
-Report.
-   - `failOnUnneeded` (**enabled** by default): Throw if there are unnecessary suppressions in the suppression file.
-   - `outputSuggested` (**enabled** by default): Output the suggested suppression file contents.
-   - `writeSuggested` (**disabled** by default): Write the suggested suppressions directly to the suppression file.
-   - `gitlab` (**disabled** by default -- parameter only): Enable the Gitlab issue searching feature.
-   - `gitlabConfiguration`:
-     - `enabled`: Whether the Gitlab configuration is enabled.
-     - `url`: The base URL of your Gitlab instance.
-     - `token`: A valid token for interacting with your Gitlab API.
-     - `populateNotesOnMatch`: Add a matching Gitlab issue URL to the notes of suppressions.
-     - `duplicateStrategy`: Either `oldest` or `newest`. If more than one issue is found matching a CVE, which one to use.
+- `--output-unneeded` or `--no-output-unneeded`: Enable/disable reporting unneeded suppressions.
+- `--output-suggested` or `--no-output-suggested`: Enable/disable reporting suggested suppression file contents.
+- `--write-suggested` or `--no-write-suggested`: Enable/disable writing suggested suppression file contents to the 
+suppression file.
+- `--gitlab-enabled` or `--gitlab-disabled`: Enable/disable the Gitlab issue searching feature.
+- `--gitlab-url=XXXX`: Set the Gitlab base URL.
+- `--gitlab-token=XXXX`: Set the Gitlab API token.
+- `--gitlab-populate-notes` or `--no-gitlab-populate-notes`: Enable/disable populating notes with Gitlab issue URLs.
+- `--gitlab-duplicate-strategy=[oldest, newest]`: When more than one issue is found, which issue to use (valid options: 
+`oldest` or `newest`).
 
-You may prepend `no` to any of the above flags, and the feature will be disabled (such as `noOutputUnneeded`).
+#### hushConfigureGitlab
 
-The above flags may also be used in `build.gradle` as config options. See below for examples.
+- `--url=XXXX`: Set the Gitlab base URL.
+- `--token=XXXX`: Set the Gitlab API token.
+- `--populate-notes` or `--no-populate-notes`: Enable/disable populating notes with Gitlab issue URLs.
+- `--duplicate-strategy=[oldest, newest]`: When more than one issue is found, which issue to use (valid options: 
+`oldest` or `newest`).
 
-### Examples
+#### hushWriteSuppressions
 
-To disable the reporting of unnecessary suppressions and suggestions, and to write directly to the suppression file
-(perhaps in a dev environment), you could run the following:
+- `--gitlab-enabled` or `--gitlab-disabled`: Enable/disable the Gitlab issue searching feature.
+- `--gitlab-url=XXXX`: Set the Gitlab base URL.
+- `--gitlab-token=XXXX`: Set the Gitlab API token.
+- `--gitlab-populate-notes` or `--no-gitlab-populate-notes`: Enable/disable populating notes with Gitlab issue URLs.
+- `--gitlab-duplicate-strategy=[oldest, newest]`: When more than one issue is found, which issue to use (valid options:
+  `oldest` or `newest`).
 
-#### In terminal
-
-```
-./gradlew hushReport -PnoOutputUnneeded -PnoOutputSuggested -PwriteSuggested
-```
-
-To disable the reporting of suggestions, you could run the following:
-
-#### In terminal
-
-```
-./gradlew hushReport -PnoOutputSuggested
-```
-
-Example configuration with default values:
-
-#### In `build.gradle`
+### Config
+Available configuration properties and their default values:
 
 ```
 hush {
@@ -61,31 +59,44 @@ hush {
    failOnUnneeded = true
    outputSuggested = true
    writeSuggested = false
-   gitlabConfiguration {
-    enabled = false
-    url = ""
-    token = ""
-    populateNotesOnMatch = true
-    duplicateStrategy = "oldest"
-  }
 }
 ```
 
-### Manually Running Sub-Tasks
+## Local development workflow with Gitlab
 
-Subtasks use their original names. You may run them per usual. For example:
+`./gradlew hushConfigureGitlab` will step you through creating a local configuration for Gitlab.
 
-   - `./gradlew dependencyCheck`
-   - `./gradlew dependencyCheckAnalyze`
+You will be given a URL to go to (but you can always just navigate to your profile in Gitlab) and generate a token. It 
+is highly recommended that the token you generate has **read-only access**, for security purposes. Hush does not 
+currently have any need for write permissions at all.
 
-### Local development workflow with Gitlab tokens
+When you run this task, a file will be created in `<user home>/.config/hush` called `hush-config.json`. This file will act as a 
+fallback for scenarios that the Gitlab configuration is not supplied via parameters. This allows an organization to 
+avoid committing tokens to source control.
 
-`./gradlew hushGitlabToken` will enable you to store a token locally, so you do not need to add a token to your `build.gradle`.
+### Notes regarding overrides
 
-First, configure your Gitlab URL. Then, run the task (`./gradlew hushGitlabToken`). You will be given a URL to go to (but you can always just navigate to your profile in Gitlab) and generate a token. It is highly recommended that the token you generate has **read-only access**, for security purposes. Hush does not currently have any need for write permissions at all.
+If you use the local development strategy, and supply config parameters via command line, command line values will 
+always override the local configuration.
 
-When you run this task and input your token, a file will be created in `<user home>/hush` called `.gitlab-token`. This file will act as a fallback for scenarios that the token is not available via configuration or parameters. This allows an organization to avoid committing tokens to source control.
+## Environment variable workflow with Gitlab
 
-#### Notes regarding overrides
+You may also define environment variables for the Gitlab configuration:
 
-If you use the local development token strategy, and later configure a token (use supply a token via command line), it will be overridden. The token file is a fallback which is only used if a token is not configured. Please keep this in mind.
+```
+HUSH_GITLAB_ENABLED
+HUSH_GITLAB_URL
+HUSH_GITLAB_TOKEN
+HUSH_GITLAB_POPULATE_NOTES
+HUSH_GITLAB_DUPLICATE_STRATEGY
+```
+
+Please note that a local configuration will be used when the file exists, and that command line parameters will always 
+override configured values. Thus, in order to utilize environment variables, a local config cannot exist, and the 
+parameters must not be defined via command line.
+
+## Caveats with writing suggested suppressions
+
+When the `--write-suggested` flag is passed to the `hushReport` task, the report will run _after_ the suppressions have 
+been written. Thus, it is important to ensure that you **do not** write suggested suppressions in a pipeline flow. If 
+you do, the pipeline will always pass, and you will never see vulnerabilities.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ previously ran `hushReport`.
   `<user home>/.config/hush/hush-config.json` to prevent committing tokens to source control. Alternatively, this file can be 
 manually created / edited with these properties: `enabled`, `url`, `token`, `populateNotesOnMatch`, and 
 `duplicateStrategy`.
+- `./gradlew hushValidatePipeline`: Perform validation without consideration for configuration values. Fails when 
+unneeded suppressions or invalid notes are found. Outputs a verbose report without suggestions.
 
 ## Arguments / Config
 
@@ -26,6 +28,7 @@ manually created / edited with these properties: `enabled`, `url`, `token`, `pop
 - `--output-suggested` or `--no-output-suggested`: Enable/disable reporting suggested suppression file contents.
 - `--write-suggested` or `--no-write-suggested`: Enable/disable writing suggested suppression file contents to the 
 suppression file.
+- `--validate-notes` or `--no-validate-notes`: Enable/disable rudimentary URL validation for notes within suppressions.
 - `--gitlab-enabled` or `--gitlab-disabled`: Enable/disable the Gitlab issue searching feature.
 - `--gitlab-url=XXXX`: Set the Gitlab base URL.
 - `--gitlab-token=XXXX`: Set the Gitlab API token.
@@ -59,6 +62,7 @@ hush {
    failOnUnneeded = true
    outputSuggested = true
    writeSuggested = false
+   validateNotes = true
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group "com.mx.hush"
-version "1.1.0"
+version "1.2.0"
 sourceCompatibility = 1.8
 
 repositories {

--- a/src/main/kotlin/com/mx/hush/HushExtension.kt
+++ b/src/main/kotlin/com/mx/hush/HushExtension.kt
@@ -25,6 +25,7 @@ open class HushExtension {
     var failOnUnneeded: Boolean = true
     var outputSuggested: Boolean = true
     var writeSuggested: Boolean = false
+    var validateNotes: Boolean = true
     var gitlabConfiguration: GitlabConfiguration = GitlabConfiguration()
 
     init {

--- a/src/main/kotlin/com/mx/hush/HushExtension.kt
+++ b/src/main/kotlin/com/mx/hush/HushExtension.kt
@@ -15,29 +15,62 @@
  */
 package com.mx.hush
 
+import com.google.gson.Gson
 import com.mx.hush.core.exceptions.GitlabConfigurationViolation
-import org.gradle.api.Action
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
 import java.io.File
-import javax.inject.Inject
 
-open class HushExtension @Inject constructor(
-    objects: ObjectFactory,
-) {
+open class HushExtension {
     var outputUnneeded: Boolean = true
     var failOnUnneeded: Boolean = true
     var outputSuggested: Boolean = true
     var writeSuggested: Boolean = false
-    val gitlabConfiguration: GitlabConfiguration = objects.newInstance(GitlabConfiguration::class.java)
+    var gitlabConfiguration: GitlabConfiguration = GitlabConfiguration()
 
-    fun gitlabConfiguration(action: Action<GitlabConfiguration>) {
-        action.execute(gitlabConfiguration)
+    init {
+        val configFile = File(gitlabConfigPath + gitlabConfigFile)
+
+        if (configFile.exists()) {
+            val config: GitlabConfiguration = Gson().fromJson(
+                configFile.readText(),
+                GitlabConfiguration::class.java)
+
+            gitlabConfiguration = config
+        } else {
+            val environmentVars = System.getenv()
+
+            if (environmentVars["HUSH_GITLAB_ENABLED"]?.isNotBlank() == true) {
+                gitlabConfiguration.enabled = environmentVars["HUSH_GITLAB_ENABLED"].toBoolean()
+            }
+
+            if (environmentVars["HUSH_GITLAB_URL"]?.isNotBlank() == true) {
+                gitlabConfiguration.url = environmentVars["HUSH_GITLAB_URL"].toString()
+            }
+
+            if (environmentVars["HUSH_GITLAB_TOKEN"]?.isNotBlank() == true) {
+                gitlabConfiguration.token = environmentVars["HUSH_GITLAB_TOKEN"].toString()
+            }
+
+            if (environmentVars["HUSH_GITLAB_POPULATE_NOTES"]?.isNotBlank() == true) {
+                gitlabConfiguration.populateNotesOnMatch = environmentVars["HUSH_GITLAB_POPULATE_NOTES"].toBoolean()
+            }
+
+            if (environmentVars["HUSH_GITLAB_DUPLICATE_STRATEGY"]?.isNotBlank() == true) {
+                gitlabConfiguration.duplicateStrategy = environmentVars["HUSH_GITLAB_DUPLICATE_STRATEGY"].toString()
+            }
+        }
     }
 
     companion object {
+        val gitlabConfigPath = "${System.getProperty("user.home")}/.config/hush/"
+        val gitlabConfigFile = "hush-config.json"
+
         fun Project.hush(): HushExtension {
             return extensions.create("hush", HushExtension::class.java)
+        }
+
+        fun Project.getHush(): HushExtension {
+            return extensions.getByType(HushExtension::class.java)
         }
     }
 }
@@ -59,15 +92,7 @@ open class GitlabConfiguration {
         }
 
         if (token.isEmpty()) {
-            if (!localTokenExists()) {
-                throw GitlabConfigurationViolation("No Gitlab token defined. Please add a token to your configuration, run the task with the gitlabConfiguration.token parameter, or run ./gradlew hushGitlabToken to set your token.")
-            }
-
-            token = File("${System.getProperty("user.home")}/hush/.gitlab-token").readText()
+            throw GitlabConfigurationViolation("No Gitlab token defined. Please configure it as an environment variable, run the task with the gitlabConfiguration.token parameter, or run ./gradlew hushConfigureGitlab.")
         }
-    }
-
-    private fun localTokenExists(): Boolean {
-        return File("${System.getProperty("user.home")}/hush/.gitlab-token").exists()
     }
 }

--- a/src/main/kotlin/com/mx/hush/HushExtension.kt
+++ b/src/main/kotlin/com/mx/hush/HushExtension.kt
@@ -92,7 +92,7 @@ open class GitlabConfiguration {
         }
 
         if (token.isEmpty()) {
-            throw GitlabConfigurationViolation("No Gitlab token defined. Please configure it as an environment variable, run the task with the gitlabConfiguration.token parameter, or run ./gradlew hushConfigureGitlab.")
+            throw GitlabConfigurationViolation("No Gitlab token defined. Please configure it as an environment variable, run the task with the gitlab-token parameter, or run ./gradlew hushConfigureGitlab.")
         }
     }
 }

--- a/src/main/kotlin/com/mx/hush/HushPlugin.kt
+++ b/src/main/kotlin/com/mx/hush/HushPlugin.kt
@@ -18,6 +18,7 @@ package com.mx.hush
 import com.mx.hush.HushExtension.Companion.hush
 import com.mx.hush.core.tasks.ConfigureGitlabTask
 import com.mx.hush.core.tasks.ReportTask
+import com.mx.hush.core.tasks.ValidatePipelineTask
 import com.mx.hush.core.tasks.WriteSuggestedTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -27,10 +28,9 @@ class HushPlugin() : Plugin<Project> {
     override fun apply(project: Project) {
         project.hush()
 
-        project.tasks.register("hushReport", ReportTask::class.java)
-        project.tasks.register("hushWriteSuppressions", WriteSuggestedTask::class.java)
         project.tasks.register("hushConfigureGitlab", ConfigureGitlabTask::class.java)
-
-        project.tasks.named("hushReport", ReportTask::class.java).orNull?.setupProject()
+        project.tasks.register("hushWriteSuppressions", WriteSuggestedTask::class.java)
+        project.tasks.register("hushReport", ReportTask::class.java).orNull?.setupProject()
+        project.tasks.register("hushValidatePipeline", ValidatePipelineTask::class.java).orNull?.setupProject()
     }
 }

--- a/src/main/kotlin/com/mx/hush/HushPlugin.kt
+++ b/src/main/kotlin/com/mx/hush/HushPlugin.kt
@@ -15,55 +15,22 @@
  */
 package com.mx.hush
 
-import com.mx.hush.core.HushEngine
-import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
-import com.mx.hush.core.exceptions.GitlabConfigurationViolation
-import com.mx.hush.core.exceptions.HushValidationViolation
-import com.mx.hush.core.models.red
+import com.mx.hush.HushExtension.Companion.hush
+import com.mx.hush.core.tasks.ConfigureGitlabTask
+import com.mx.hush.core.tasks.ReportTask
+import com.mx.hush.core.tasks.WriteSuggestedTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import java.io.File
 
 
 class HushPlugin() : Plugin<Project> {
     override fun apply(project: Project) {
-        val dependencyCheckDriver = DependencyCheckVulnerabilityScanDriver(project)
-        val hushEngine = HushEngine(project, dependencyCheckDriver)
+        project.hush()
 
-        project.tasks.register("hushReport") { task ->
-            task.description = "Check dependencies and output a report."
-            task.doLast {
-                hushEngine.analyze()
-            }
-        }
+        project.tasks.register("hushReport", ReportTask::class.java)
+        project.tasks.register("hushWriteSuppressions", WriteSuggestedTask::class.java)
+        project.tasks.register("hushConfigureGitlab", ConfigureGitlabTask::class.java)
 
-        project.tasks.register("hushGitlabToken") { task ->
-            task.description = "Set a local Gitlab token, for use in Hush, to avoid storing in a Git repository."
-
-            val tokenFile = File("${System.getProperty("user.home")}/hush/.gitlab-token")
-
-            task.doFirst {
-                File("${System.getProperty("user.home")}/hush").mkdirs()
-                tokenFile.createNewFile()
-            }
-
-            task.doLast {
-                if (hushEngine.getGitlabUrl().isBlank()) {
-                    println(red("Please configure a Gitlab URL."))
-                    throw GitlabConfigurationViolation("No Gitlab URL configured.")
-                }
-
-                println("Please visit ${hushEngine.getGitlabTokenUrl()}, add a token, and paste it below:")
-                val token = readLine()
-
-                if (token.isNullOrBlank()) {
-                    throw HushValidationViolation("Invalid token entered. Exiting.")
-                }
-
-                tokenFile.writeText(token)
-            }
-        }
-
-
+        project.tasks.named("hushReport", ReportTask::class.java).orNull?.setupProject()
     }
 }

--- a/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
@@ -75,7 +75,7 @@ class HushDeltaAnalyzer(private val vulnerabilities: HashMap<String, HushVulnera
         try {
             passOrFail(failOnUnneeded, validateNotes)
         } catch (_: HushValidationViolation) {
-            throw HushValidationViolation(red("Project failed validation. Please run hushReport locally for details."))
+            throw HushValidationViolation(red("Project failed validation."))
         }
     }
 

--- a/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushDeltaAnalyzer.kt
@@ -63,6 +63,14 @@ class HushDeltaAnalyzer(private val vulnerabilities: HashMap<String, HushVulnera
         println(green("Project passed validation."))
     }
 
+    fun passOrFailPipeline(failOnUnneeded: Boolean) {
+        try {
+            passOrFail(failOnUnneeded)
+        } catch (_: HushValidationViolation) {
+            throw HushValidationViolation(red("Project failed validation. Please run hushReport locally for details."))
+        }
+    }
+
     /**
      * Print report based on validation
      * Will print non-suppressed vulnerabilities

--- a/src/main/kotlin/com/mx/hush/core/HushEngine.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushEngine.kt
@@ -25,7 +25,7 @@ import org.gradle.api.Project
 class HushEngine(project: Project, private val scanDriver: HushVulnerabilityScanDriver) {
     private var extension = project.getHush()
 
-    fun analyze() {
+    fun validateAndReport() {
         extension.gitlabConfiguration.validateConfiguration()
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
 
@@ -38,6 +38,34 @@ class HushEngine(project: Project, private val scanDriver: HushVulnerabilityScan
 
         analyzer.printReport(extension.outputUnneeded, extension.outputSuggested)
         analyzer.passOrFail(extension.failOnUnneeded)
+    }
+
+    fun validate(forceAll: Boolean) {
+        val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
+
+        if (forceAll) {
+            analyzer.passOrFail(true)
+            return
+        }
+
+        analyzer.passOrFail(extension.failOnUnneeded)
+    }
+
+    fun validatePipeline() {
+        val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
+
+        analyzer.passOrFailPipeline(true)
+    }
+
+    fun report(forceAll: Boolean) {
+        val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
+
+        if (forceAll) {
+            analyzer.printReport(true, true)
+            return
+        }
+
+        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested)
     }
 
     fun writeSuggestedSuppressions() {

--- a/src/main/kotlin/com/mx/hush/core/HushEngine.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushEngine.kt
@@ -15,63 +15,50 @@
  */
 package com.mx.hush.core
 
-import com.mx.hush.HushExtension.Companion.hush
+import com.mx.hush.HushExtension.Companion.getHush
 import com.mx.hush.core.drivers.HushVulnerabilityScanDriver
 import com.mx.hush.core.models.HushSuppression
 import com.mx.hush.core.models.HushVulnerability
 import com.mx.hush.core.models.green
-import com.mx.hush.core.models.red
 import org.gradle.api.Project
 
-class HushEngine(private val project: Project, private val scanDriver: HushVulnerabilityScanDriver) {
-    private val configParameters = hashMapOf(
-        // Output unneeded suppressions
-        "outputUnneeded" to true,
-        // Throw if unneeded suppressions are found
-        "failOnUnneeded" to true,
-        // Output suggested suppressions
-        "outputSuggested" to true,
-        // Write the suggested suppressions to the suppression file
-        "writeSuggested" to false,
-        // Use the Gitlab configuration
-        "gitlab" to false,
-    )
-
-    private var extension = project.hush()
-    private var gitlabConfiguration = extension.gitlabConfiguration
-
-    init {
-        project.afterEvaluate {
-            initializeConfigParameters()
-        }
-
-        setupProject()
-    }
+class HushEngine(project: Project, private val scanDriver: HushVulnerabilityScanDriver) {
+    private var extension = project.getHush()
 
     fun analyze() {
         extension.gitlabConfiguration.validateConfiguration()
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
 
-        if (getConfigParameter("writeSuggested")) {
+        if (extension.writeSuggested) {
             analyzer.writeSuggestedSuppressions()
             analyzer.reInitialize(getSuppressions())
 
             println(green("Suppression file written."))
         }
 
-        analyzer.printReport(getConfigParameter("outputUnneeded"), getConfigParameter("outputSuggested"))
-        analyzer.passOrFail(getConfigParameter("failOnUnneeded"))
+        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested)
+        analyzer.passOrFail(extension.failOnUnneeded)
     }
 
-    fun getGitlabTokenUrl(): String {
-        return "${getGitlabUrl()}/-/profile/personal_access_tokens"
+    fun writeSuggestedSuppressions() {
+        val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
+
+        analyzer.writeSuggestedSuppressions()
     }
 
-    fun getGitlabUrl(): String {
-        return extension.gitlabConfiguration.url
+    fun canWriteSuggestedSuppressions(): Boolean {
+        return scanDriver.canWriteSuggestedSuppressions()
     }
 
-    private fun setupProject() {
+    fun getReportFilePath(): String {
+        return scanDriver.getReportFilePath()
+    }
+
+    fun getSuppressionFilePath(): String {
+        return scanDriver.getSuppressionFilePath()
+    }
+
+    fun setupProject() {
         scanDriver.setupProject()
     }
 
@@ -81,87 +68,5 @@ class HushEngine(private val project: Project, private val scanDriver: HushVulne
 
     private fun getSuppressions(): List<HushSuppression> {
         return scanDriver.getSuppressions()!!
-    }
-
-    private fun initializeConfigParameters() {
-        initalizeBaseConfigParameters()
-        initalizeGitlabConfigParameters()
-    }
-
-    private fun initalizeBaseConfigParameters() {
-        configParameters["outputUnneeded"] = extension.outputUnneeded
-        configParameters["failOnUnneeded"] = extension.failOnUnneeded
-        configParameters["outputSuggested"] = extension.outputSuggested
-        configParameters["writeSuggested"] = extension.writeSuggested
-        configParameters["gitlab"] = extension.gitlabConfiguration.enabled
-
-        for (configItem in configParameters.keys) {
-            for (parameter in project.properties) {
-                val key = parameter.key.toLowerCase()
-
-                if (key == configItem.toLowerCase()) {
-                    configParameters[configItem] = true
-
-                    println("$configItem enabled via parameter")
-                }
-
-                if (key == "no${configItem.toLowerCase()}") {
-                    configParameters[configItem] = false
-
-                    println("$configItem disabled via parameter")
-                }
-            }
-        }
-    }
-
-    private fun initalizeGitlabConfigParameters() {
-        gitlabConfiguration = extension.gitlabConfiguration
-
-        for (parameter in project.properties) {
-            val key = parameter.key.toLowerCase()
-
-            if (key.contains(".")) {
-                val keys = key.split(".")
-
-                if (keys[0] == "gitlabconfiguration") {
-                    when (keys[1]) {
-                        "url" -> {
-                            extension.gitlabConfiguration.url = parameter.value.toString()
-                            println("Gitlab host set to ${parameter.value.toString()} via parameter")
-                        }
-
-                        "token" -> {
-                            extension.gitlabConfiguration.token = parameter.value.toString()
-                            println("Gitlab token set via parameter")
-                        }
-
-                        "populatenotesonmatch" -> {
-                            extension.gitlabConfiguration.populateNotesOnMatch = parameter.value.toString().toBoolean()
-                            println("Gitlab populateNotesOnMatch set to ${parameter.value.toString().toBoolean()} via parameter")
-                        }
-
-                        "duplicatestrategy" -> {
-                            val strategy = if (parameter.value.toString() == "oldest") "oldest" else "newest"
-                            extension.gitlabConfiguration.duplicateStrategy = strategy
-                            println("Gitlab duplicateStrategy set to $strategy via parameter")
-                        }
-
-                        else -> {
-                            println(red("Unknown Gitlab configuration property '${keys[1]}'"))
-                        }
-                    }
-                }
-            }
-        }
-
-        extension.gitlabConfiguration.enabled = configParameters["gitlab"] == true
-    }
-
-    private fun getConfigParameter(parameter: String): Boolean {
-        if (!configParameters.containsKey(parameter)) {
-            return false
-        }
-
-        return configParameters[parameter] as Boolean
     }
 }

--- a/src/main/kotlin/com/mx/hush/core/HushEngine.kt
+++ b/src/main/kotlin/com/mx/hush/core/HushEngine.kt
@@ -36,36 +36,36 @@ class HushEngine(project: Project, private val scanDriver: HushVulnerabilityScan
             println(green("Suppression file written."))
         }
 
-        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested)
-        analyzer.passOrFail(extension.failOnUnneeded)
+        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested, extension.validateNotes)
+        analyzer.passOrFail(extension.failOnUnneeded, extension.validateNotes)
     }
 
     fun validate(forceAll: Boolean) {
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
 
         if (forceAll) {
-            analyzer.passOrFail(true)
+            analyzer.passOrFail(true, true)
             return
         }
 
-        analyzer.passOrFail(extension.failOnUnneeded)
+        analyzer.passOrFail(extension.failOnUnneeded, extension.validateNotes)
     }
 
     fun validatePipeline() {
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
 
-        analyzer.passOrFailPipeline(true)
+        analyzer.passOrFailPipeline(true, true)
     }
 
     fun report(forceAll: Boolean) {
         val analyzer = HushDeltaAnalyzer(getVulnerabilities(), getSuppressions(), scanDriver, extension.gitlabConfiguration)
 
         if (forceAll) {
-            analyzer.printReport(true, true)
+            analyzer.printReport(true, false, true)
             return
         }
 
-        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested)
+        analyzer.printReport(extension.outputUnneeded, extension.outputSuggested, extension.validateNotes)
     }
 
     fun writeSuggestedSuppressions() {

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
@@ -165,6 +165,25 @@ class DependencyCheckVulnerabilityScanDriver(private val project: Project) : Hus
         File(suppressionFilepath).writeText(suppressions)
     }
 
+    /**
+     * Validate that the report + suppression files exist and can be read
+     */
+    override fun canWriteSuggestedSuppressions(): Boolean {
+        if (!File(suppressionFilepath).exists()) {
+            File(suppressionFilepath).createNewFile()
+        }
+
+        return File(reportFilepath).canRead() && File(suppressionFilepath).canWrite()
+    }
+
+    override fun getReportFilePath(): String {
+        return reportFilepath
+    }
+
+    override fun getSuppressionFilePath(): String {
+        return suppressionFilepath
+    }
+
     private fun getReport(): DependencyCheckScanReport? {
         return try {
             Gson().fromJson(readFileDirectlyAsText(reportFilepath), DependencyCheckScanReport::class.java)

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
@@ -17,6 +17,7 @@ package com.mx.hush.core.drivers
 
 import com.google.gson.Gson
 import com.mx.hush.core.models.*
+import org.apache.commons.validator.routines.UrlValidator
 import org.gradle.api.Project
 import org.gradle.internal.impldep.jakarta.xml.bind.Marshaller
 import org.owasp.dependencycheck.gradle.extension.DependencyCheckExtension
@@ -176,12 +177,41 @@ class DependencyCheckVulnerabilityScanDriver(private val project: Project) : Hus
         return File(reportFilepath).canRead() && File(suppressionFilepath).canWrite()
     }
 
+    /**
+     * Get the report file path
+     */
     override fun getReportFilePath(): String {
         return reportFilepath
     }
 
+    /**
+     * Get the suppression file path
+     */
     override fun getSuppressionFilePath(): String {
         return suppressionFilepath
+    }
+
+    /**
+     * Performs rudimentary validation on a note, ensuring it is a URL
+     */
+    override fun isValidNote(note: String): Boolean {
+        val validator = UrlValidator()
+        return validator.isValid(note)
+    }
+
+    /**
+     * Get a list of suppressions with invalid (non-URL) notes
+     */
+    override fun getInvalidNotes(suppressions: List<HushSuppression>): List<HushSuppression> {
+        val invalidNotes = mutableListOf<HushSuppression>()
+
+        suppressions.forEach { suppression ->
+            if (suppression.notes == null || !isValidNote(suppression.notes.toString())) {
+                invalidNotes.add(HushSuppression(suppression.cve, suppression.notes))
+            }
+        }
+
+        return invalidNotes
     }
 
     private fun getReport(): DependencyCheckScanReport? {

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -18,7 +18,6 @@ package com.mx.hush.core.drivers
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.httpGet
 import com.mx.hush.GitlabConfiguration
-import com.mx.hush.core.models.HushSuppression
 import com.mx.hush.core.models.gitlab.GitlabIssue
 
 class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfiguration) : HushIssueSearchDriver() {
@@ -42,13 +41,5 @@ class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfigurati
         }
 
         return issues.last().webUrl
-    }
-
-    override fun isValidNote(note: String): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override fun validateNotes(suppressions: List<HushSuppression>) {
-        TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/GitlabIssueSearchDriver.kt
@@ -33,6 +33,10 @@ class GitlabIssueSearchDriver(private val gitlabConfiguration: GitlabConfigurati
 
         val issues = result.component1() ?: return urlFallbackMessage
 
+        if (issues.isEmpty()) {
+            return urlFallbackMessage
+        }
+
         if (gitlabConfiguration.duplicateStrategy != "oldest") {
             return issues.first().webUrl
         }

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushIssueSearchDriver.kt
@@ -15,10 +15,6 @@
  */
 package com.mx.hush.core.drivers
 
-import com.mx.hush.core.models.HushSuppression
-
 abstract class HushIssueSearchDriver() {
     abstract fun findIssueUrl(cve: String): String
-    abstract fun isValidNote(note: String): Boolean
-    abstract fun validateNotes(suppressions: List<HushSuppression>)
 }

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
@@ -47,4 +47,19 @@ abstract class HushVulnerabilityScanDriver(private val project: Project) {
      * Write suggested suppression file text to the suppression file
      */
     abstract fun writeSuggestedSuppressions(suppressions: String)
+
+    /**
+     * Validates that suggested suppressions can be generated and written
+     */
+    abstract fun canWriteSuggestedSuppressions(): Boolean
+
+    /**
+     * Returns the path to the report file
+     */
+    abstract fun getReportFilePath(): String
+
+    /**
+     * Returns the path to the suppression file
+     */
+    abstract fun getSuppressionFilePath(): String
 }

--- a/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/HushVulnerabilityScanDriver.kt
@@ -62,4 +62,14 @@ abstract class HushVulnerabilityScanDriver(private val project: Project) {
      * Returns the path to the suppression file
      */
     abstract fun getSuppressionFilePath(): String
+
+    /**
+     * Performs rudimentary validation on a note
+     */
+    abstract fun isValidNote(note: String): Boolean
+
+    /**
+     * Returns a list of suppressions with invalid notes
+     */
+    abstract fun getInvalidNotes(suppressions: List<HushSuppression>): List<HushSuppression>
 }

--- a/src/main/kotlin/com/mx/hush/core/exceptions/HushIOReadWriteViolation.kt
+++ b/src/main/kotlin/com/mx/hush/core/exceptions/HushIOReadWriteViolation.kt
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mx.hush.core.exceptions
+
+class HushIOReadWriteViolation(message: String) : RuntimeException(message)

--- a/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
@@ -1,0 +1,92 @@
+package com.mx.hush.core.tasks
+
+import com.google.gson.Gson
+import com.mx.hush.GitlabConfiguration
+import com.mx.hush.HushExtension
+import com.mx.hush.core.models.green
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+
+open class ConfigureGitlabTask : DefaultTask() {
+    init {
+        description = "Setup a local configuration for the Gitlab integration."
+        group = "Reporting"
+    }
+
+    @set:Option(
+        option = "url",
+        description = "The base URL (https://mygitlab.mycompany.com) of your Gitlab instance."
+    )
+    @get:Input
+    var url: String = ""
+
+    @set:Option(
+        option = "token",
+        description = "The token for making API requests to your Gitlab instance."
+    )
+    @get:Input
+    var token: String = ""
+
+    @set:Option(
+        option = "populate-notes",
+        description = "Populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var populateNotes: Boolean = false
+
+    @set:Option(
+        option = "no-populate-notes",
+        description = "Do not populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var noPopulateNotes: Boolean = false
+
+    @set:Option(
+        option = "duplicate-strategy",
+        description = "Which strategy to use when more than one issue is found in Gitlab matching the CVE (oldest/newest)"
+    )
+    @get:Input
+    var duplicateStrategy: String = ""
+
+    @TaskAction
+    fun configureGitlab() {
+        val configFile = File(HushExtension.gitlabConfigPath + HushExtension.gitlabConfigFile)
+
+        File(HushExtension.gitlabConfigPath).mkdirs()
+        configFile.createNewFile()
+
+        if (url.isEmpty()) {
+            println("Please enter your Gitlab base URL (ex. https://mygitlab.mydomain.com)")
+            url = readLine().toString()
+        }
+
+        if (token.isEmpty()) {
+            println("Please visit $url/-/profile/personal_access_tokens, add a token, and paste it below:")
+            token = readLine().toString()
+        }
+
+        if (!populateNotes && !noPopulateNotes) {
+            println("Would you like to populate suppression notes with Gitlab issue URLs? (y/n)")
+            populateNotes = readLine().toString().toLowerCase() == "y"
+        }
+
+        if (duplicateStrategy.isEmpty()) {
+            println("If duplicate issues are found, should Hush pick the oldest or newest issue? (oldest/newest)")
+            duplicateStrategy = if (readLine().toString().toLowerCase() == "oldest") "oldest" else "newest"
+        }
+
+        val gitlabConfig = GitlabConfiguration()
+        gitlabConfig.enabled = true
+        gitlabConfig.url = url
+        gitlabConfig.token = token
+        gitlabConfig.populateNotesOnMatch = (populateNotes && !noPopulateNotes)
+        gitlabConfig.duplicateStrategy = duplicateStrategy
+
+        configFile.writeText(Gson().toJson(gitlabConfig, GitlabConfiguration::class.java))
+
+        println(green("Configuration written to ${HushExtension.gitlabConfigPath}${HushExtension.gitlabConfigFile}"))
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mx.hush.core.tasks
 
 import com.google.gson.Gson

--- a/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
 import java.io.File
 
 open class ConfigureGitlabTask : DefaultTask() {
@@ -65,6 +66,10 @@ open class ConfigureGitlabTask : DefaultTask() {
     )
     @get:Input
     var duplicateStrategy: String = ""
+    @OptionValues
+    fun getDuplicateStrategies(): List<String> {
+        return listOf("oldest", "newest")
+    }
 
     @TaskAction
     fun configureGitlab() {

--- a/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ConfigureGitlabTask.kt
@@ -66,7 +66,7 @@ open class ConfigureGitlabTask : DefaultTask() {
     )
     @get:Input
     var duplicateStrategy: String = ""
-    @OptionValues
+    @OptionValues("duplicate-strategy")
     fun getDuplicateStrategies(): List<String> {
         return listOf("oldest", "newest")
     }

--- a/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
@@ -1,0 +1,152 @@
+package com.mx.hush.core.tasks
+
+import com.mx.hush.HushExtension.Companion.getHush
+import com.mx.hush.core.HushEngine
+import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
+
+open class ReportTask : DefaultTask() {
+    private val dependencyCheckDriver = DependencyCheckVulnerabilityScanDriver(project)
+    private val hushEngine = HushEngine(project, dependencyCheckDriver)
+    private val extension = project.getHush()
+
+    init {
+        description = "Check dependencies for vulnerabilities, validate suppression file, and output a report."
+        group = "Reporting"
+    }
+
+    @set:Option(
+        option = "output-unneeded",
+        description = "Report suppressions found in the suppression file which are not needed."
+    )
+    @get:Input
+    var outputUnneeded: Boolean = extension.outputUnneeded
+
+    @set:Option(
+        option = "no-output-unneeded",
+        description = "Do not report suppressions found in the suppression file which are not needed."
+    )
+    @get:Input
+    var noOutputUnneeded: Boolean = false
+
+    @set:Option(
+        option = "fail-on-unneeded",
+        description = "Fail if suppressions are found in the suppression file which are not needed."
+    )
+    @get:Input
+    var failOnUnneeded: Boolean = extension.failOnUnneeded
+
+    @set:Option(
+        option = "no-fail-on-unneeded",
+        description = "Do not fail if suppressions are found in the suppression file which are not needed."
+    )
+    @get:Input
+    var noFailOnUnneeded: Boolean = false
+
+    @set:Option(
+        option = "output-suggested",
+        description = "Output suggested suppression file contents."
+    )
+    @get:Input
+    var outputSuggested: Boolean = extension.outputSuggested
+
+    @set:Option(
+        option = "no-output-suggested",
+        description = "Do not output suggested suppression file contents."
+    )
+    @get:Input
+    var noOutputSuggested: Boolean = false
+
+    @set:Option(
+        option = "write-suggested",
+        description = "Write suggested suppression file contents to the suppression file."
+    )
+    @get:Input
+    var writeSuggested: Boolean = extension.writeSuggested
+
+    @set:Option(
+        option = "no-write-suggested",
+        description = "Do not write suggested suppression file contents to the suppression file."
+    )
+    @get:Input
+    var noWriteSuggested: Boolean = false
+
+    @set:Option(
+        option = "gitlab-enabled",
+        description = "Enable the Gitlab feature."
+    )
+    @get:Input
+    var gitlabEnabled: Boolean = extension.gitlabConfiguration.enabled
+
+    @set:Option(
+        option = "gitlab-disabled",
+        description = "Disable the Gitlab feature."
+    )
+    @get:Input
+    var gitlabDisabled: Boolean = false
+
+    @set:Option(
+        option = "gitlab-url",
+        description = "The base URL (https://mygitlab.mycompany.com) of your Gitlab instance."
+    )
+    @get:Input
+    var gitlabUrl: String = extension.gitlabConfiguration.url
+
+    @set:Option(
+        option = "gitlab-token",
+        description = "The token for making API requests to your Gitlab instance."
+    )
+    @get:Input
+    var gitlabToken: String = extension.gitlabConfiguration.token
+
+    @set:Option(
+        option = "gitlab-populate-notes",
+        description = "Populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var gitlabPopulateNotes: Boolean = extension.gitlabConfiguration.populateNotesOnMatch
+
+    @set:Option(
+        option = "no-gitlab-populate-notes",
+        description = "Populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var noGitlabPopulateNotes: Boolean = false
+
+    @set:Option(
+        option = "gitlab-duplicate-strategy",
+        description = "Which strategy to use when more than one issue is found in Gitlab matching the CVE (oldest/newest)"
+    )
+    @get:Input
+    var gitlabDuplicateStrategy: String = extension.gitlabConfiguration.duplicateStrategy
+    @OptionValues
+    fun getDuplicateStrategies(): List<String> {
+        return listOf("oldest", "newest")
+    }
+
+    @TaskAction
+    fun report() {
+        handleParameters()
+        hushEngine.analyze()
+    }
+
+    fun setupProject() {
+        hushEngine.setupProject()
+    }
+
+    private fun handleParameters() {
+        extension.outputUnneeded = (outputUnneeded && !noOutputUnneeded)
+        extension.failOnUnneeded = (failOnUnneeded && !noFailOnUnneeded)
+        extension.outputSuggested = (outputSuggested && !noOutputSuggested)
+        extension.writeSuggested = (writeSuggested && !noWriteSuggested)
+        extension.gitlabConfiguration.enabled = (gitlabEnabled && !gitlabDisabled)
+        extension.gitlabConfiguration.url = gitlabUrl
+        extension.gitlabConfiguration.token = gitlabToken
+        extension.gitlabConfiguration.populateNotesOnMatch = (gitlabPopulateNotes && !noGitlabPopulateNotes)
+        extension.gitlabConfiguration.duplicateStrategy = gitlabDuplicateStrategy
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
@@ -146,7 +146,7 @@ open class ReportTask : DefaultTask() {
     @TaskAction
     fun report() {
         handleParameters()
-        hushEngine.analyze()
+        hushEngine.validateAndReport()
     }
 
     fun setupProject() {

--- a/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
@@ -91,6 +91,20 @@ open class ReportTask : DefaultTask() {
     var noWriteSuggested: Boolean = false
 
     @set:Option(
+        option = "validate-notes",
+        description = "Validate notes with rudimentary URL validation, ensuring it is at least a URL."
+    )
+    @get:Input
+    var validateNotes: Boolean = extension.validateNotes
+
+    @set:Option(
+        option = "no-validate-notes",
+        description = "Do not validate notes with rudimentary URL validation."
+    )
+    @get:Input
+    var noValidateNotes: Boolean = false
+
+    @set:Option(
         option = "gitlab-enabled",
         description = "Enable the Gitlab feature."
     )
@@ -158,6 +172,7 @@ open class ReportTask : DefaultTask() {
         extension.failOnUnneeded = (failOnUnneeded && !noFailOnUnneeded)
         extension.outputSuggested = (outputSuggested && !noOutputSuggested)
         extension.writeSuggested = (writeSuggested && !noWriteSuggested)
+        extension.validateNotes = (validateNotes && !noValidateNotes)
         extension.gitlabConfiguration.enabled = (gitlabEnabled && !gitlabDisabled)
         extension.gitlabConfiguration.url = gitlabUrl
         extension.gitlabConfiguration.token = gitlabToken

--- a/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mx.hush.core.tasks
 
 import com.mx.hush.HushExtension.Companion.getHush

--- a/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ReportTask.kt
@@ -138,7 +138,7 @@ open class ReportTask : DefaultTask() {
     )
     @get:Input
     var gitlabDuplicateStrategy: String = extension.gitlabConfiguration.duplicateStrategy
-    @OptionValues
+    @OptionValues("gitlab-duplicate-strategy")
     fun getDuplicateStrategies(): List<String> {
         return listOf("oldest", "newest")
     }

--- a/src/main/kotlin/com/mx/hush/core/tasks/ValidatePipelineTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ValidatePipelineTask.kt
@@ -1,0 +1,25 @@
+package com.mx.hush.core.tasks
+
+import com.mx.hush.core.HushEngine
+import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+open class ValidatePipelineTask : DefaultTask() {
+    private val dependencyCheckDriver = DependencyCheckVulnerabilityScanDriver(project)
+    private val hushEngine = HushEngine(project, dependencyCheckDriver)
+
+    init {
+        description = "Check dependencies for vulnerabilities, validate suppression file, and pass/fail without report."
+        group = "Verification"
+    }
+
+    @TaskAction
+    fun report() {
+        hushEngine.validatePipeline()
+    }
+
+    fun setupProject() {
+        hushEngine.setupProject()
+    }
+}

--- a/src/main/kotlin/com/mx/hush/core/tasks/ValidatePipelineTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/ValidatePipelineTask.kt
@@ -16,6 +16,7 @@ open class ValidatePipelineTask : DefaultTask() {
 
     @TaskAction
     fun report() {
+        hushEngine.report(true)
         hushEngine.validatePipeline()
     }
 

--- a/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
@@ -24,6 +24,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+import org.gradle.api.tasks.options.OptionValues
 import java.io.File
 
 open class WriteSuggestedTask : DefaultTask() {
@@ -84,6 +85,10 @@ open class WriteSuggestedTask : DefaultTask() {
     )
     @get:Input
     var gitlabDuplicateStrategy: String = extension.gitlabConfiguration.duplicateStrategy
+    @OptionValues
+    fun getDuplicateStrategies(): List<String> {
+        return listOf("oldest", "newest")
+    }
 
     @TaskAction
     fun writeSuggested() {

--- a/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
@@ -85,7 +85,7 @@ open class WriteSuggestedTask : DefaultTask() {
     )
     @get:Input
     var gitlabDuplicateStrategy: String = extension.gitlabConfiguration.duplicateStrategy
-    @OptionValues
+    @OptionValues("gitlab-duplicate-strategy")
     fun getDuplicateStrategies(): List<String> {
         return listOf("oldest", "newest")
     }

--- a/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2020 MX Technologies.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mx.hush.core.tasks
 
 import com.mx.hush.HushExtension.Companion.getHush

--- a/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
+++ b/src/main/kotlin/com/mx/hush/core/tasks/WriteSuggestedTask.kt
@@ -1,0 +1,98 @@
+package com.mx.hush.core.tasks
+
+import com.mx.hush.HushExtension.Companion.getHush
+import com.mx.hush.core.HushEngine
+import com.mx.hush.core.drivers.DependencyCheckVulnerabilityScanDriver
+import com.mx.hush.core.exceptions.HushIOReadWriteViolation
+import com.mx.hush.core.models.red
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+
+open class WriteSuggestedTask : DefaultTask() {
+    private val dependencyCheckDriver = DependencyCheckVulnerabilityScanDriver(project)
+    private val hushEngine = HushEngine(project, dependencyCheckDriver)
+    private val extension = project.getHush()
+
+    init {
+        description = "Write the suggested contents of the vulnerability suppression file. Requires previously running hushReport."
+        group = "Reporting"
+    }
+
+    @set:Option(
+        option = "gitlab-enabled",
+        description = "Enable the Gitlab feature."
+    )
+    @get:Input
+    var gitlabEnabled: Boolean = extension.gitlabConfiguration.enabled
+
+    @set:Option(
+        option = "gitlab-disabled",
+        description = "Disable the Gitlab feature."
+    )
+    @get:Input
+    var gitlabDisabled: Boolean = false
+
+    @set:Option(
+        option = "gitlab-url",
+        description = "The base URL (https://mygitlab.mycompany.com) of your Gitlab instance."
+    )
+    @get:Input
+    var gitlabUrl: String = extension.gitlabConfiguration.url
+
+    @set:Option(
+        option = "gitlab-token",
+        description = "The token for making API requests to your Gitlab instance."
+    )
+    @get:Input
+    var gitlabToken: String = extension.gitlabConfiguration.token
+
+    @set:Option(
+        option = "gitlab-populate-notes",
+        description = "Populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var gitlabPopulateNotes: Boolean = extension.gitlabConfiguration.populateNotesOnMatch
+
+    @set:Option(
+        option = "no-gitlab-populate-notes",
+        description = "Populate notes in suggested suppressions with an issue URL from your Gitlab (when found)."
+    )
+    @get:Input
+    var noGitlabPopulateNotes: Boolean = false
+
+    @set:Option(
+        option = "gitlab-duplicate-strategy",
+        description = "Which strategy to use when more than one issue is found in Gitlab matching the CVE (oldest/newest)"
+    )
+    @get:Input
+    var gitlabDuplicateStrategy: String = extension.gitlabConfiguration.duplicateStrategy
+
+    @TaskAction
+    fun writeSuggested() {
+        if (!hushEngine.canWriteSuggestedSuppressions()) {
+            if(!File(hushEngine.getReportFilePath()).canRead()) {
+                println(red("Could not read file at '${hushEngine.getReportFilePath()}'. Please make sure you run hushReport before attempting this task."))
+            }
+
+            if(!File(hushEngine.getSuppressionFilePath()).canWrite()) {
+                println(red("Could not write file at '${hushEngine.getSuppressionFilePath()}'. Please make sure the file permissions are set properly."))
+            }
+
+            throw HushIOReadWriteViolation("Could not write suppressions due to a read/write violation.")
+        }
+
+        handleParameters()
+        hushEngine.writeSuggestedSuppressions()
+    }
+
+    private fun handleParameters() {
+        extension.gitlabConfiguration.enabled = (gitlabEnabled && !gitlabDisabled)
+        extension.gitlabConfiguration.url = gitlabUrl
+        extension.gitlabConfiguration.token = gitlabToken
+        extension.gitlabConfiguration.populateNotesOnMatch = (gitlabPopulateNotes && !noGitlabPopulateNotes)
+        extension.gitlabConfiguration.duplicateStrategy = gitlabDuplicateStrategy
+    }
+}


### PR DESCRIPTION
# What's new

## Overview

- Sane flags / run parameters. What used to be `-PwriteSuggested` is now `--write-suggested`.
- Removed the option to configure Gitlab inside of `build.gradle`.
   - For the local flow, use `./gradlew hushConfigureGitlab` which will write the entire config to a non-project config file.
   - For pipelines, you may leverage either run parameters (such as `gitlab-enabled`, `gitlab-host=XXXX`, etc), or the newly added environment variables.
- `./gradlew hushConfigureGitlab` is a new step-by-step configuration process for setting up Gitlab.
- `./gradlew hushWriteSuppressions` is a new command which will simply write the suggested suppressions.
- `./gradlew hushValidatePipeline` is a new command which will force all validation, disregarding configuration values, and output a verbose report without suggestions.

## Breaking Changes

Config blocks for `gitlabConfiguration` will cause Hush to fail. Please ensure you remove them from `build.gradle`.