### PR TITLE
2.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group "com.mx.hush"
-version "1.2.0"
+version "2.0.0"
 sourceCompatibility = 1.8
 
 repositories {


### PR DESCRIPTION
# What's new

## Overview

- Sane flags / run parameters. What used to be `-PwriteSuggested` is now `--write-suggested`.
- Removed the option to configure Gitlab inside of `build.gradle`.
   - For the local flow, use `./gradlew hushConfigureGitlab` which will write the entire config to a non-project config file.
   - For pipelines, you may leverage either run parameters (such as `gitlab-enabled`, `gitlab-host=XXXX`, etc), or the newly added environment variables.
- `./gradlew hushConfigureGitlab` is a new step-by-step configuration process for setting up Gitlab.
- `./gradlew hushWriteSuppressions` is a new command which will simply write the suggested suppressions.
- `./gradlew hushValidatePipeline` is a new command which will force all validation, disregarding configuration values, and output a verbose report without suggestions.

## Breaking Changes

Config blocks for `gitlabConfiguration` will cause Hush to fail. Please ensure you remove them from `build.gradle`.