### PR TITLE
2.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group "com.mx.hush"
-version "2.0.0"
+version "2.0.1"
 sourceCompatibility = 1.8
 
 repositories {

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
@@ -85,6 +85,10 @@ class DependencyCheckVulnerabilityScanDriver(private val project: Project) : Hus
             project.tasks.named("hushReport")
                 .get()
                 .dependsOn(project.tasks.named("dependencyCheckAnalyze"))
+
+            project.tasks.named("hushValidatePipeline")
+                .get()
+                .dependsOn(project.tasks.named("dependencyCheckAnalyze"))
         }
     }
 


### PR DESCRIPTION
Force `hushValidatePipeline` to depend on `dependencyCheckAnalyze`