### PR TITLE
upgrading Hush to java17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 group "com.mx.hush"
 version "2.1.0"
 sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories {
     mavenCentral()
@@ -24,6 +25,8 @@ dependencies {
     implementation "org.owasp:dependency-check-gradle:7.1.1"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.3")
     implementation("com.github.kittinunf.fuel:fuel:2.3.1")
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:3.+")
+    implementation("com.sun.xml.bind:jaxb-impl:3.0.2")
 }
 
 gradlePlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/mx/hush/core/models/ObjectFactory.java
+++ b/src/main/java/com/mx/hush/core/models/ObjectFactory.java
@@ -17,9 +17,9 @@ package com.mx.hush.core.models;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlElementDecl;
-import javax.xml.bind.annotation.XmlRegistry;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlElementDecl;
+import jakarta.xml.bind.annotation.XmlRegistry;
 import javax.xml.namespace.QName;
 
 

--- a/src/main/java/com/mx/hush/core/models/RegexStringType.java
+++ b/src/main/java/com/mx/hush/core/models/RegexStringType.java
@@ -15,11 +15,11 @@
  */
 package com.mx.hush.core.models;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 
 /**

--- a/src/main/java/com/mx/hush/core/models/Suppressions.java
+++ b/src/main/java/com/mx/hush/core/models/Suppressions.java
@@ -19,15 +19,15 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElementRef;
-import javax.xml.bind.annotation.XmlElementRefs;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElementRef;
+import jakarta.xml.bind.annotation.XmlElementRefs;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlSchemaType;
+import jakarta.xml.bind.annotation.XmlType;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 

--- a/src/main/java/com/mx/hush/core/models/package-info.java
+++ b/src/main/java/com/mx/hush/core/models/package-info.java
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package com.mx.hush.core.models;

--- a/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
+++ b/src/main/kotlin/com/mx/hush/core/drivers/DependencyCheckVulnerabilityScanDriver.kt
@@ -29,7 +29,7 @@ import java.io.FileNotFoundException
 import java.io.StringWriter
 import java.util.Arrays
 import java.util.Collections
-import javax.xml.bind.JAXBContext
+import jakarta.xml.bind.JAXBContext
 import kotlin.collections.HashMap
 
 /**

--- a/src/main/kotlin/com/mx/hush/core/models/DependencyCheckScanSuppression.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/DependencyCheckScanSuppression.kt
@@ -15,7 +15,7 @@
  */
 package com.mx.hush.core.models
 
-import javax.xml.bind.annotation.*
+import jakarta.xml.bind.annotation.*
 
 @XmlRootElement(name = "suppress")
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/src/main/kotlin/com/mx/hush/core/models/DependencyCheckScanSuppressions.kt
+++ b/src/main/kotlin/com/mx/hush/core/models/DependencyCheckScanSuppressions.kt
@@ -15,7 +15,7 @@
  */
 package com.mx.hush.core.models
 
-import javax.xml.bind.annotation.*
+import jakarta.xml.bind.annotation.*
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "", propOrder = ["suppress"])


### PR DESCRIPTION
Moving Hush to Java 17. It is backward compatible with Java 8.